### PR TITLE
Combined tokens orderbook

### DIFF
--- a/stats_utils.py
+++ b/stats_utils.py
@@ -118,21 +118,30 @@ def get_and_parse_orderbook(pair):
     if "-ERC20" not in pair[0]:
         pair_erc20_a = (pair[0] + "-ERC20", pair[1])
         pair_erc20_a_orderbok = get_mm2_orderbook_for_pair(pair_erc20_a)
+        # case when there is no such ticker in coins file
+        if next(iter(pair_erc20_a_orderbok)) == "error":
+            pair_erc20_a_orderbok = {"bids" : [], "asks": []}
     else:
         pair_erc20_a_orderbok =  {"bids" : [], "asks": []}
     if "-ERC20" not in pair[1]:
         pair_erc20_b = (pair[0], pair[1] + "-ERC20")
         pair_erc20_b_orderbok = get_mm2_orderbook_for_pair(pair_erc20_b)
+        if next(iter(pair_erc20_b_orderbok)) == "error":
+            pair_erc20_b_orderbok = {"bids" : [], "asks": []}
     else:
         pair_erc20_b_orderbook = {"bids" : [], "asks": []}
     if "-BEP20" not in pair[0]:
         pair_bep20_a = (pair[0] + "-BEP20", pair[1])
         pair_bep20_a_orderbok = get_mm2_orderbook_for_pair(pair_bep20_a)
+        if next(iter(pair_bep20_a_orderbok)) == "error":
+            pair_bep20_a_orderbok = {"bids" : [], "asks": []}
     else:
         pair_bep20_a_orderbok = {"bids" : [], "asks": []}
     if "-BEP20" not in pair[1]:
         pair_bep20_b = (pair[0], pair[1] + "-BEP20")
         pair_bep20_b_orderbok = get_mm2_orderbook_for_pair(pair_bep20_b)
+        if next(iter(pair_bep20_a_orderbok)) == "error":
+            pair_bep20_b_orderbok = {"bids" : [], "asks": []}
     else:
         pair_bep20_b_orderbok = {"bids" : [], "asks": []}
     usual_orderbook = get_mm2_orderbook_for_pair(pair)

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -118,39 +118,32 @@ def get_and_parse_orderbook(pair):
     if "-ERC20" not in pair[0]:
         pair_erc20_a = (pair[0] + "-ERC20", pair[1])
         pair_erc20_a_orderbook = get_mm2_orderbook_for_pair(pair_erc20_a)
-        # case when there is no such ticker in coins file
-        if next(iter(pair_erc20_a_orderbook)) == "error":
-            pair_erc20_a_orderbook = {"bids" : [], "asks": []}
     else:
         pair_erc20_a_orderbook =  {"bids" : [], "asks": []}
     if "-ERC20" not in pair[1]:
         pair_erc20_b = (pair[0], pair[1] + "-ERC20")
         pair_erc20_b_orderbook = get_mm2_orderbook_for_pair(pair_erc20_b)
-        if next(iter(pair_erc20_b_orderbook)) == "error":
-            pair_erc20_b_orderbook = {"bids" : [], "asks": []}
     else:
         pair_erc20_b_orderbook = {"bids" : [], "asks": []}
     if "-BEP20" not in pair[0]:
         pair_bep20_a = (pair[0] + "-BEP20", pair[1])
         pair_bep20_a_orderbook = get_mm2_orderbook_for_pair(pair_bep20_a)
-        if next(iter(pair_bep20_a_orderbook)) == "error":
-            pair_bep20_a_orderbook = {"bids" : [], "asks": []}
     else:
         pair_bep20_a_orderbook = {"bids" : [], "asks": []}
     if "-BEP20" not in pair[1]:
         pair_bep20_b = (pair[0], pair[1] + "-BEP20")
         pair_bep20_b_orderbook = get_mm2_orderbook_for_pair(pair_bep20_b)
-        if next(iter(pair_bep20_b_orderbook)) == "error":
-            pair_bep20_b_orderbook = {"bids" : [], "asks": []}
     else:
         pair_bep20_b_orderbook = {"bids" : [], "asks": []}
     usual_orderbook = get_mm2_orderbook_for_pair(pair)
-    if next(iter(usual_orderbook)) == "error":
-        usual_orderbook = {"bids" : [], "asks": []}
+    orderbooks_list = [usual_orderbook, pair_erc20_a_orderbook, pair_erc20_b_orderbook, pair_bep20_a_orderbook, pair_bep20_b_orderbook]
     orderbook = {"bids" : [], "asks": []}
-    # TODO: make list with orderbooks and iterate for error key and combining
-    orderbook["bids"] = usual_orderbook["bids"] + pair_erc20_a_orderbook["bids"] + pair_erc20_b_orderbook["bids"] + pair_bep20_a_orderbook["bids"] + pair_bep20_b_orderbook["bids"]
-    orderbook["asks"] = usual_orderbook["asks"] + pair_erc20_a_orderbook["asks"] + pair_erc20_b_orderbook["asks"] + pair_bep20_a_orderbook["asks"] + pair_bep20_b_orderbook["asks"]
+    for orderbook_permutation in orderbooks_list:
+        # case when there is no such ticker in coins file
+        if next(iter(orderbook_permutation)) == "error":
+            orderbook_permutation = {"bids" : [], "asks": []}
+        orderbook["bids"] += orderbook_permutation["bids"]
+        orderbook["asks"] += orderbook_permutation["asks"]
     bids_converted_list = []
     asks_converted_list = []
     try:

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -115,35 +115,28 @@ def find_highest_bid(orderbook):
     return highest_bid["price"]
 
 def get_and_parse_orderbook(pair):
-    if "-ERC20" not in pair[0]:
+    if "-ERC20" not in pair[0] and "-ERC20" not in pair[1] and "-BEP20" not in pair[0] and "-BEP20" not in pair[1]:
         pair_erc20_a = (pair[0] + "-ERC20", pair[1])
         pair_erc20_a_orderbook = get_mm2_orderbook_for_pair(pair_erc20_a)
-    else:
-        pair_erc20_a_orderbook =  {"bids" : [], "asks": []}
-    if "-ERC20" not in pair[1]:
         pair_erc20_b = (pair[0], pair[1] + "-ERC20")
         pair_erc20_b_orderbook = get_mm2_orderbook_for_pair(pair_erc20_b)
-    else:
-        pair_erc20_b_orderbook = {"bids" : [], "asks": []}
-    if "-BEP20" not in pair[0]:
         pair_bep20_a = (pair[0] + "-BEP20", pair[1])
         pair_bep20_a_orderbook = get_mm2_orderbook_for_pair(pair_bep20_a)
-    else:
-        pair_bep20_a_orderbook = {"bids" : [], "asks": []}
-    if "-BEP20" not in pair[1]:
         pair_bep20_b = (pair[0], pair[1] + "-BEP20")
         pair_bep20_b_orderbook = get_mm2_orderbook_for_pair(pair_bep20_b)
+        usual_orderbook = get_mm2_orderbook_for_pair(pair)
+        orderbooks_list = [usual_orderbook, pair_erc20_a_orderbook, pair_erc20_b_orderbook, pair_bep20_a_orderbook, pair_bep20_b_orderbook]
+        orderbook = {"bids" : [], "asks": []}
+        for orderbook_permutation in orderbooks_list:
+            # case when there is no such ticker in coins file
+            if next(iter(orderbook_permutation)) == "error":
+                orderbook_permutation = {"bids" : [], "asks": []}
+            orderbook["bids"] += orderbook_permutation["bids"]
+            orderbook["asks"] += orderbook_permutation["asks"]
     else:
-        pair_bep20_b_orderbook = {"bids" : [], "asks": []}
-    usual_orderbook = get_mm2_orderbook_for_pair(pair)
-    orderbooks_list = [usual_orderbook, pair_erc20_a_orderbook, pair_erc20_b_orderbook, pair_bep20_a_orderbook, pair_bep20_b_orderbook]
-    orderbook = {"bids" : [], "asks": []}
-    for orderbook_permutation in orderbooks_list:
-        # case when there is no such ticker in coins file
-        if next(iter(orderbook_permutation)) == "error":
-            orderbook_permutation = {"bids" : [], "asks": []}
-        orderbook["bids"] += orderbook_permutation["bids"]
-        orderbook["asks"] += orderbook_permutation["asks"]
+        orderbook = get_mm2_orderbook_for_pair(pair)
+        if next(iter(orderbook)) == "error":
+            orderbook = {"bids" : [], "asks": []}
     bids_converted_list = []
     asks_converted_list = []
     try:

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -117,37 +117,38 @@ def find_highest_bid(orderbook):
 def get_and_parse_orderbook(pair):
     if "-ERC20" not in pair[0]:
         pair_erc20_a = (pair[0] + "-ERC20", pair[1])
-        pair_erc20_a_orderbok = get_mm2_orderbook_for_pair(pair_erc20_a)
+        pair_erc20_a_orderbook = get_mm2_orderbook_for_pair(pair_erc20_a)
         # case when there is no such ticker in coins file
-        if next(iter(pair_erc20_a_orderbok)) == "error":
-            pair_erc20_a_orderbok = {"bids" : [], "asks": []}
+        if next(iter(pair_erc20_a_orderbook)) == "error":
+            pair_erc20_a_orderbook = {"bids" : [], "asks": []}
     else:
-        pair_erc20_a_orderbok =  {"bids" : [], "asks": []}
+        pair_erc20_a_orderbook =  {"bids" : [], "asks": []}
     if "-ERC20" not in pair[1]:
         pair_erc20_b = (pair[0], pair[1] + "-ERC20")
-        pair_erc20_b_orderbok = get_mm2_orderbook_for_pair(pair_erc20_b)
-        if next(iter(pair_erc20_b_orderbok)) == "error":
-            pair_erc20_b_orderbok = {"bids" : [], "asks": []}
+        pair_erc20_b_orderbook = get_mm2_orderbook_for_pair(pair_erc20_b)
+        if next(iter(pair_erc20_b_orderbook)) == "error":
+            pair_erc20_b_orderbook = {"bids" : [], "asks": []}
     else:
         pair_erc20_b_orderbook = {"bids" : [], "asks": []}
     if "-BEP20" not in pair[0]:
         pair_bep20_a = (pair[0] + "-BEP20", pair[1])
-        pair_bep20_a_orderbok = get_mm2_orderbook_for_pair(pair_bep20_a)
-        if next(iter(pair_bep20_a_orderbok)) == "error":
-            pair_bep20_a_orderbok = {"bids" : [], "asks": []}
+        pair_bep20_a_orderbook = get_mm2_orderbook_for_pair(pair_bep20_a)
+        if next(iter(pair_bep20_a_orderbook)) == "error":
+            pair_bep20_a_orderbook = {"bids" : [], "asks": []}
     else:
-        pair_bep20_a_orderbok = {"bids" : [], "asks": []}
+        pair_bep20_a_orderbook = {"bids" : [], "asks": []}
     if "-BEP20" not in pair[1]:
         pair_bep20_b = (pair[0], pair[1] + "-BEP20")
-        pair_bep20_b_orderbok = get_mm2_orderbook_for_pair(pair_bep20_b)
-        if next(iter(pair_bep20_a_orderbok)) == "error":
-            pair_bep20_b_orderbok = {"bids" : [], "asks": []}
+        pair_bep20_b_orderbook = get_mm2_orderbook_for_pair(pair_bep20_b)
+        if next(iter(pair_bep20_b_orderbook)) == "error":
+            pair_bep20_b_orderbook = {"bids" : [], "asks": []}
     else:
-        pair_bep20_b_orderbok = {"bids" : [], "asks": []}
+        pair_bep20_b_orderbook = {"bids" : [], "asks": []}
     usual_orderbook = get_mm2_orderbook_for_pair(pair)
     orderbook = {"bids" : [], "asks": []}
-    orderbook["bids"] = pair_erc20_a_orderbok["bids"] + pair_erc20_b_orderbok["bids"] + pair_bep20_a_orderbok["bids"] + pair_bep20_b_orderbok["bids"]
-    orderbook["asks"] = pair_erc20_a_orderbok["asks"] + pair_erc20_b_orderbok["asks"] + pair_bep20_a_orderbok["asks"] + pair_bep20_b_orderbok["asks"]
+    # TODO: make list with orderbooks and iterate for error key and combining
+    orderbook["bids"] = usual_orderbook["bids"] + pair_erc20_a_orderbook["bids"] + pair_erc20_b_orderbook["bids"] + pair_bep20_a_orderbook["bids"] + pair_bep20_b_orderbook["bids"]
+    orderbook["asks"] = usual_orderbook["asks"] + pair_erc20_a_orderbook["asks"] + pair_erc20_b_orderbook["asks"] + pair_bep20_a_orderbook["asks"] + pair_bep20_b_orderbook["asks"]
     bids_converted_list = []
     asks_converted_list = []
     try:

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -115,7 +115,30 @@ def find_highest_bid(orderbook):
     return highest_bid["price"]
 
 def get_and_parse_orderbook(pair):
-    orderbook = get_mm2_orderbook_for_pair(pair)
+    if "-ERC20" not in pair[0]:
+        pair_erc20_a = (pair[0] + "-ERC20", pair[1])
+        pair_erc20_a_orderbok = get_mm2_orderbook_for_pair(pair_erc20_a)
+    else:
+        pair_erc20_a_orderbok =  {"bids" : [], "asks": []}
+    if "-ERC20" not in pair[1]:
+        pair_erc20_b = (pair[0], pair[1] + "-ERC20")
+        pair_erc20_b_orderbok = get_mm2_orderbook_for_pair(pair_erc20_b)
+    else:
+        pair_erc20_b_orderbook = {"bids" : [], "asks": []}
+    if "-BEP20" not in pair[0]:
+        pair_bep20_a = (pair[0] + "-BEP20", pair[1])
+        pair_bep20_a_orderbok = get_mm2_orderbook_for_pair(pair_bep20_a)
+    else:
+        pair_bep20_a_orderbok = {"bids" : [], "asks": []}
+    if "-BEP20" not in pair[1]:
+        pair_bep20_b = (pair[0], pair[1] + "-BEP20")
+        pair_bep20_b_orderbok = get_mm2_orderbook_for_pair(pair_bep20_b)
+    else:
+        pair_bep20_b_orderbok = {"bids" : [], "asks": []}
+    usual_orderbook = get_mm2_orderbook_for_pair(pair)
+    orderbook = {"bids" : [], "asks": []}
+    orderbook["bids"] = pair_erc20_a_orderbok["bids"] + pair_erc20_b_orderbok["bids"] + pair_bep20_a_orderbok["bids"] + pair_bep20_b_orderbok["bids"]
+    orderbook["asks"] = pair_erc20_a_orderbok["asks"] + pair_erc20_b_orderbok["asks"] + pair_bep20_a_orderbok["asks"] + pair_bep20_b_orderbok["asks"]
     bids_converted_list = []
     asks_converted_list = []
     try:

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -145,6 +145,8 @@ def get_and_parse_orderbook(pair):
     else:
         pair_bep20_b_orderbook = {"bids" : [], "asks": []}
     usual_orderbook = get_mm2_orderbook_for_pair(pair)
+    if next(iter(usual_orderbook)) == "error":
+        usual_orderbook = {"bids" : [], "asks": []}
     orderbook = {"bids" : [], "asks": []}
     # TODO: make list with orderbooks and iterate for error key and combining
     orderbook["bids"] = usual_orderbook["bids"] + pair_erc20_a_orderbook["bids"] + pair_erc20_b_orderbook["bids"] + pair_bep20_a_orderbook["bids"] + pair_bep20_b_orderbook["bids"]


### PR DESCRIPTION
cf: https://github.com/tonymorony/dexstats_sqlite_py/issues/15

@cipig I've added more logic into order book call to parse more liquidity across the protocol for the CEX aggregators

now if let's say you call http://95.217.208.239:8080/api/v1/orderbook/KMD_USDC API will try to get and combine all mm2 orderbooks variations bids and asks such as:

KMD / USDC 

KMD-BEP20 / USDC
KMD-ERC20 / USDC 

KMD / USDC-ERC20
KMD / USDC-BEP20

and provide it as a call result

could you please check if it works on stage http://95.217.208.239:8080/api/v1/orderbook as expected?
if everything looks fine I'll update the production endpoint with these changes
