### PR TITLE
Restore liquidity values in API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.json
+*.txt
+*.csv
+*.log
+*.db
+.env
+MM2.db

--- a/main.py
+++ b/main.py
@@ -26,8 +26,7 @@ def cache_gecko_data():
         with open('gecko_cache.json', 'w') as json_file:
             json_file.write(json.dumps(gecko_data))
     except Exception as e:
-        print(e)
-    print("saved gecko data to file")
+        print(f"Error in [cache_gecko_data]: {e}")
 
 @app.get('/api/v1/summary')
 def summary():

--- a/refresh_coins_config.sh
+++ b/refresh_coins_config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd /home/atomic/dexstats_sqlite_py
+sha_local=($(sha256sum ./coins_config.json))
+curl -s https://raw.githubusercontent.com/KomodoPlatform/coins/master/utils/coins_config.json --output coins_config.new
+sha_remote=($(sha256sum ./coins_config.new))
+
+if [[ $sha_local != $sha_remote ]]; then
+  rm coins_config.json && mv coins_config.new coins_config.json
+else
+  rm coins_config.new
+fi


### PR DESCRIPTION
- Added .gitignore to ignore files not needing to be commited.
- Added a script for updating coins_config.json (set to cron daily)
- Fixed issue with gecko url failing due to duplicated gecko_ids in the query url
- Limited `available_pairs` response to last 7 days rather than since forever.

@cipig reported that coinpaprika was not returning liquidity data. After investigation, it was found that the CoinGecko API url for getting prices was returning a [414 error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414), and the cause was duplicated coin_id values in the url making it too long. I've modified the code to remove the duplicates which has resolved this issue for now, though in future with additional coins we may face the same problem and be required to split our request into parts. An issue for this has been created at https://github.com/KomodoPlatform/dexstats_sqlite_py/issues/14

With the URL now returning a response, liquidity data was restored in https://stats-api.atomicdex.io/api/v1/atomicdexio

Next problem was requests to https://stats-api.atomicdex.io/api/v1/summary would often return a [504 error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) as the backend was taking too long to generate the response. This is due to a few reasons:
- https://github.com/KomodoPlatform/dexstats_sqlite_py/blob/main/stats_utils.py#L323-L324 uses a loop over `available_pairs` which makes a query to MM2.db 
- `available_pairs` was a list of all pairs with at least one swap from the complete database (around 2230 pairs). 
- looking at the fastAPI logs, there is a lot of activity on this API, and potential for [Error - SQLITE_BUSY: database is locked] (https://activesphere.com/blog/2018/12/24/understanding-sqlite-busy)

The fastest way to resolve this was to reduce the `available_pairs` count but adding a condition to only return pairs traded in the last 7 days. In the long run, it would be better to avoid the looping of queries by using different SQL, different db and/or caching pair swaps data. Some work toward this is ongoing in the `dockerised` branch.

This PR is just a quick patch to resolve immediate issues, with a more complete solution to come later.
