### PR TITLE
extend pair retention for summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,8 @@ COINS_URL=https://raw.githubusercontent.com/KomodoPlatform/coins/master/coins
 - To test everything: `pytest -v`
 - To test a specific file: `pytest -v tests/test_file.py`
 
+### Source Data
+
+If you have access, you can get a well populated MM2.db file with:
+`rsync username@stats-api.atomicdex.io:/DB/43ec929fe30ee72be42c9162c56dde910a05e50d/MM2.db . --progress -v -r`
 

--- a/logger.py
+++ b/logger.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 import logging
+import os
+import sys
 
+logger_app_name = os.path.basename(sys.argv[0]).split(".")[0]
 
 class CustomFormatter(logging.Formatter):
 
@@ -27,15 +30,15 @@ class CustomFormatter(logging.Formatter):
     red = "\x1b[31;20m"
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
-    format = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s (%(filename)s:%(lineno)d)"
-    datefmt = '%d-%b-%y %H:%M:%S'
+    format = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)-80s (%(filename)s:%(lineno)d)"  # type: ignore
+    datefmt = "%d-%b-%y %H:%M:%S"
 
     FORMATS = {
-        logging.DEBUG: lightblue + format + reset,
-        logging.INFO: lightgreen + format + reset,
-        logging.WARNING: red + format + reset,
-        logging.ERROR: lightred + format + reset,
-        logging.CRITICAL: bold_red + format + reset
+        logging.DEBUG: f"{lightblue}{format}{reset}",
+        logging.INFO: f"{lightgreen}{format}{reset}",
+        logging.WARNING: f"{red}{format}{reset}",
+        logging.ERROR: f"{lightred}{format}{reset}",
+        logging.CRITICAL: f"{bold_red}{format}{reset}",
     }
 
     def format(self, record):
@@ -44,11 +47,22 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-# create logger with 'destats_app'
-logger = logging.getLogger("dexstats_app")
+# create logger with project folder name
+logging.basicConfig()
+logger = logging.getLogger(logger_app_name)
 logger.setLevel(logging.DEBUG)
+logger.propagate = False
 
 # create console handler with a higher log level
 handler = logging.StreamHandler()
 handler.setFormatter(CustomFormatter())
 logger.addHandler(handler)
+
+
+if __name__ == "__main__":
+    logger.debug("debug message")
+    logger.info("info message")
+    logger.warning("warn message")
+    logger.error("error message")
+    logger.critical("critical message")
+    logger.info(f"logger_app_name: {logger_app_name}")

--- a/main.py
+++ b/main.py
@@ -87,7 +87,10 @@ def update_coins():  # pragma: no cover
 # //////////////////////////// #
 @app.get('/api/v1/atomicdexio')
 def atomicdexio():
-    '''Simple Summary Statistics for last 24 hours'''
+    '''
+    Simple Summary Statistics used on atomicdex.io website.
+    Updates every 10 minutes.
+    '''
     try:
         return cache.load.atomicdexio()
     except Exception as e:  # pragma: no cover
@@ -97,7 +100,10 @@ def atomicdexio():
 
 @app.get('/api/v1/atomicdex_fortnight')
 def atomicdex_fortnight():
-    '''Extra Summary Statistics over last 2 weeks'''
+    '''
+    Verbose Summary Statistics for the last 14 days.
+    Updates every 10 minutes.
+    '''
     try:
         return cache.load.atomicdex_fortnight()
     except Exception as e:  # pragma: no cover
@@ -108,7 +114,7 @@ def atomicdex_fortnight():
 @app.get('/api/v1/summary')
 def summary():
     '''
-    Trade summary for the last 24 hours for all
+    Pair summary for the last 24 hours for all
     pairs traded in the last 7 days.
     '''
     try:

--- a/tests/fixtures/coins_config.json
+++ b/tests/fixtures/coins_config.json
@@ -34,7 +34,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -77,7 +77,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -123,7 +123,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -181,7 +181,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -241,7 +241,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -359,7 +359,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -405,7 +405,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -451,7 +451,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -493,7 +493,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -558,7 +558,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -634,7 +634,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -761,7 +761,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -863,7 +863,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -921,7 +921,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -985,7 +985,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -1061,7 +1061,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -1105,7 +1105,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -1181,7 +1181,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -1228,7 +1228,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -1304,7 +1304,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -1349,7 +1349,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -1408,7 +1408,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -1484,7 +1484,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -1531,7 +1531,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -1607,7 +1607,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -1666,7 +1666,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -1709,7 +1709,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -1754,7 +1754,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -1813,7 +1813,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -1967,7 +1967,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2025,7 +2025,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2084,7 +2084,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -2175,7 +2175,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2262,7 +2262,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -2304,7 +2304,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2413,7 +2413,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -2459,7 +2459,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -2644,7 +2644,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2708,7 +2708,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -2820,7 +2820,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2878,7 +2878,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -2943,7 +2943,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -3061,7 +3061,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -3106,7 +3106,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -3164,7 +3164,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -3224,7 +3224,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -3300,7 +3300,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -3343,7 +3343,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -3389,7 +3389,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -3436,7 +3436,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -3511,7 +3511,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -3612,7 +3612,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -3913,7 +3913,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -4085,7 +4085,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -4164,7 +4164,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -4240,7 +4240,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -4444,7 +4444,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -4640,7 +4640,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -4786,7 +4786,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -4887,7 +4887,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -5033,7 +5033,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -5098,7 +5098,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -5174,7 +5174,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -5325,7 +5325,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -5386,7 +5386,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -5463,7 +5463,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -5510,7 +5510,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -5881,7 +5881,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -5993,7 +5993,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -6215,7 +6215,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -6274,7 +6274,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -6339,7 +6339,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -6415,7 +6415,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -6563,7 +6563,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -6622,7 +6622,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -6665,7 +6665,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -6755,7 +6755,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -6830,7 +6830,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -6889,7 +6889,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -6936,7 +6936,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -7013,7 +7013,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -7059,7 +7059,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -7118,7 +7118,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -7447,7 +7447,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -7523,7 +7523,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -7575,7 +7575,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -7651,7 +7651,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -7710,7 +7710,7 @@
         "fallback_swap_contract": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/arbitrum",
+                "url": "https://node.komodo.earth:8080/arbitrum",
                 "gui_auth": true
             },
             {
@@ -7753,7 +7753,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -7985,7 +7985,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -8061,7 +8061,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -8108,7 +8108,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -8226,7 +8226,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -8316,7 +8316,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -8358,7 +8358,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -8423,7 +8423,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -8541,7 +8541,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -8588,7 +8588,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -8706,7 +8706,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -8753,7 +8753,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -8829,7 +8829,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -8872,7 +8872,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -8957,7 +8957,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -9107,7 +9107,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -9167,7 +9167,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -9243,7 +9243,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -9291,7 +9291,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -9366,7 +9366,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -9425,7 +9425,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -9552,7 +9552,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -9708,7 +9708,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -9788,7 +9788,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -10239,7 +10239,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -10315,7 +10315,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -10440,7 +10440,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -10611,7 +10611,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -10671,7 +10671,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -10899,7 +10899,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -10957,7 +10957,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -11015,7 +11015,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -11073,7 +11073,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -11453,7 +11453,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -11513,7 +11513,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -11588,7 +11588,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -11653,7 +11653,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -11841,7 +11841,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -11959,7 +11959,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -12004,7 +12004,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -12107,7 +12107,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -12161,7 +12161,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -12237,7 +12237,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -12273,7 +12273,7 @@
         "fallback_swap_contract": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/arbitrum",
+                "url": "https://node.komodo.earth:8080/arbitrum",
                 "gui_auth": true
             },
             {
@@ -12315,7 +12315,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -12374,7 +12374,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -12501,7 +12501,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -12548,7 +12548,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -12625,7 +12625,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -12677,7 +12677,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -12754,7 +12754,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -12838,7 +12838,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -12915,7 +12915,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -12991,7 +12991,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -13050,7 +13050,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -13095,7 +13095,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -13155,7 +13155,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -13353,7 +13353,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -13569,7 +13569,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -13627,7 +13627,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -13685,7 +13685,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -13745,7 +13745,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -13821,7 +13821,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -14135,7 +14135,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -14177,7 +14177,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -14241,7 +14241,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -14317,7 +14317,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -14377,7 +14377,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -14453,7 +14453,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -14499,7 +14499,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -14584,7 +14584,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -14628,7 +14628,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -14704,7 +14704,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -14763,7 +14763,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -14931,7 +14931,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -15007,7 +15007,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -15052,7 +15052,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -15111,7 +15111,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -15170,7 +15170,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -15218,7 +15218,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -15294,7 +15294,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -15340,7 +15340,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -15481,7 +15481,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -15557,7 +15557,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -16590,7 +16590,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -16639,7 +16639,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -16757,7 +16757,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -16803,7 +16803,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -16863,7 +16863,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -16940,7 +16940,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -17022,7 +17022,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -17098,7 +17098,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -17250,7 +17250,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -17326,7 +17326,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -17415,7 +17415,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -17492,7 +17492,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -17652,7 +17652,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -17837,7 +17837,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -17896,7 +17896,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -17942,7 +17942,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -17989,7 +17989,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -18065,7 +18065,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18125,7 +18125,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -18200,7 +18200,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18259,7 +18259,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -18334,7 +18334,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18392,7 +18392,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18451,7 +18451,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -18496,7 +18496,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18555,7 +18555,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -18602,7 +18602,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18662,7 +18662,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -18709,7 +18709,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -18756,7 +18756,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -18799,7 +18799,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -18859,7 +18859,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -18936,7 +18936,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -18983,7 +18983,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19030,7 +19030,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -19073,7 +19073,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -19133,7 +19133,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -19210,7 +19210,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19257,7 +19257,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -19317,7 +19317,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -19394,7 +19394,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19441,7 +19441,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19488,7 +19488,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19535,7 +19535,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19582,7 +19582,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19629,7 +19629,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19676,7 +19676,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19723,7 +19723,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19770,7 +19770,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -19814,7 +19814,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19861,7 +19861,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -19937,7 +19937,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -19983,7 +19983,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -20030,7 +20030,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -20077,7 +20077,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -20124,7 +20124,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -20171,7 +20171,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -20487,7 +20487,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -20545,7 +20545,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -20609,7 +20609,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -20685,7 +20685,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -20731,7 +20731,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -20879,7 +20879,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -21255,7 +21255,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -21331,7 +21331,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -21432,7 +21432,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -21508,7 +21508,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -21554,7 +21554,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -21630,7 +21630,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -21672,7 +21672,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -21731,7 +21731,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -21858,7 +21858,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -21904,7 +21904,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -21969,7 +21969,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -22045,7 +22045,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -22104,7 +22104,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -22236,7 +22236,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -22318,7 +22318,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -22394,7 +22394,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -22453,7 +22453,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -22805,7 +22805,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -22881,7 +22881,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -22982,7 +22982,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -23028,7 +23028,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -23088,7 +23088,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -23164,7 +23164,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -23244,7 +23244,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -23289,7 +23289,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -23353,7 +23353,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -23514,7 +23514,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -23590,7 +23590,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -23969,7 +23969,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -24151,7 +24151,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -24227,7 +24227,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -24286,7 +24286,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -24328,7 +24328,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -24393,7 +24393,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -24515,7 +24515,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -24591,7 +24591,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -24634,7 +24634,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -24735,7 +24735,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -25217,7 +25217,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -25275,7 +25275,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -25403,7 +25403,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -25521,7 +25521,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -25844,7 +25844,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -26017,7 +26017,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -26094,7 +26094,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -26140,7 +26140,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -26204,7 +26204,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -26280,7 +26280,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -26332,7 +26332,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -26408,7 +26408,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -26447,7 +26447,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/harmony",
+                "url": "https://node.komodo.earth:8080/harmony",
                 "gui_auth": true
             },
             {
@@ -26492,7 +26492,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -26661,7 +26661,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -26736,7 +26736,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -26837,7 +26837,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -26882,7 +26882,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -26947,7 +26947,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -27023,7 +27023,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -27157,7 +27157,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -27233,7 +27233,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -27284,7 +27284,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -27360,7 +27360,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -27460,7 +27460,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -27536,7 +27536,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -27581,7 +27581,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -27641,7 +27641,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -27717,7 +27717,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -27832,7 +27832,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -27895,7 +27895,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -28351,7 +28351,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -28414,7 +28414,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -28496,7 +28496,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -28962,7 +28962,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -29315,7 +29315,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -29437,7 +29437,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -29514,7 +29514,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -29590,7 +29590,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -30061,7 +30061,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -30137,7 +30137,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -30184,7 +30184,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -30260,7 +30260,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -30307,7 +30307,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -30389,7 +30389,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -30503,7 +30503,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -30673,7 +30673,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -30749,7 +30749,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -30808,7 +30808,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -30854,7 +30854,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -30913,7 +30913,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -30972,7 +30972,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -31014,7 +31014,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -31079,7 +31079,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -31155,7 +31155,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -31240,7 +31240,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -31286,7 +31286,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -31345,7 +31345,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -31391,7 +31391,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -31573,7 +31573,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -31649,7 +31649,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -31800,7 +31800,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -31842,7 +31842,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -31907,7 +31907,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -31983,7 +31983,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -32110,7 +32110,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -32155,7 +32155,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -32213,7 +32213,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -32273,7 +32273,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -32619,7 +32619,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -32916,7 +32916,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -33034,7 +33034,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -33080,7 +33080,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33188,7 +33188,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33329,7 +33329,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -33405,7 +33405,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33512,7 +33512,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33571,7 +33571,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33630,7 +33630,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -33673,7 +33673,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33733,7 +33733,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -33780,7 +33780,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -33856,7 +33856,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -33920,7 +33920,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -33996,7 +33996,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -34039,7 +34039,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -34166,7 +34166,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -34212,7 +34212,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -34276,7 +34276,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -34352,7 +34352,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -34441,7 +34441,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -34485,7 +34485,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -34561,7 +34561,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -34607,7 +34607,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -34655,7 +34655,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -34730,7 +34730,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -34873,7 +34873,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -34968,7 +34968,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -35011,7 +35011,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -35059,7 +35059,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -35134,7 +35134,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -35192,7 +35192,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -35361,7 +35361,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -35407,7 +35407,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -35467,7 +35467,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -35585,7 +35585,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -35712,7 +35712,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -35758,7 +35758,7 @@
         "fallback_swap_contract": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/arbitrum",
+                "url": "https://node.komodo.earth:8080/arbitrum",
                 "gui_auth": true
             },
             {
@@ -35801,7 +35801,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -35844,7 +35844,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -35886,7 +35886,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -35949,7 +35949,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -36025,7 +36025,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -36192,7 +36192,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -36250,7 +36250,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -36327,7 +36327,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -36403,7 +36403,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -36540,7 +36540,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -37076,7 +37076,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -37141,7 +37141,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -37217,7 +37217,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -37264,7 +37264,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -37340,7 +37340,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -37383,7 +37383,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -37442,7 +37442,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -37485,7 +37485,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -37532,7 +37532,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -37608,7 +37608,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -37667,7 +37667,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -37727,7 +37727,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -37804,7 +37804,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -37849,7 +37849,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -38095,7 +38095,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -38155,7 +38155,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -38237,7 +38237,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -38314,7 +38314,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -38360,7 +38360,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -38458,7 +38458,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -38669,7 +38669,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -38728,7 +38728,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -38770,7 +38770,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -38835,7 +38835,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -38911,7 +38911,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/fantom",
+                "url": "https://node.komodo.earth:8080/fantom",
                 "gui_auth": true
             },
             {
@@ -38996,7 +38996,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -39041,7 +39041,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -39106,7 +39106,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -39405,7 +39405,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -39502,7 +39502,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -39664,7 +39664,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/avalanche",
+                "url": "https://node.komodo.earth:8080/avalanche",
                 "gui_auth": true
             },
             {
@@ -39713,7 +39713,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -39789,7 +39789,7 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/polygon",
+                "url": "https://node.komodo.earth:8080/polygon",
                 "gui_auth": true
             },
             {
@@ -39997,7 +39997,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -40072,7 +40072,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -41049,7 +41049,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41130,7 +41130,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41212,7 +41212,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41294,7 +41294,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41371,7 +41371,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41448,7 +41448,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41529,7 +41529,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41606,7 +41606,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41688,7 +41688,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41769,7 +41769,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41887,7 +41887,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -41964,7 +41964,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42045,7 +42045,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42127,7 +42127,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42204,7 +42204,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42281,7 +42281,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42362,7 +42362,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42439,7 +42439,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42516,7 +42516,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42592,7 +42592,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -42652,7 +42652,7 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/ethereum",
+                "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
             },
             {
@@ -42728,7 +42728,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -43337,7 +43337,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -43602,7 +43602,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -43801,7 +43801,7 @@
         "swap_contract_address": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.live:8080/binance",
+                "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
             },
             {
@@ -43893,7 +43893,7 @@
         "derivation_path": "m/44'/566'",
         "rpc_urls": [
             {
-                "url": "https://iris.komodo.live/"
+                "url": "https://iris.komodo.earth/"
             },
             {
                 "url": "https://rpc.irishub-1.irisnet.org"
@@ -43965,7 +43965,7 @@
         "parent_coin": "IRIS",
         "rpc_urls": [
             {
-                "url": "https://iris.komodo.live/"
+                "url": "https://iris.komodo.earth/"
             },
             {
                 "url": "https://rpc.irishub-1.irisnet.org"


### PR DESCRIPTION
- `api/v1/summary` endpoint still provides summary of last 24 hours for a pair, but output retains all pairs traded in last 24 hours (and last price). Requested by @cipig on behalf of CoinPaprika
- Refactored `DexAPI` class
- tweaked logging
- 